### PR TITLE
coverage map idea from Grafana

### DIFF
--- a/learn/index.html
+++ b/learn/index.html
@@ -103,6 +103,8 @@
             <section id="coverage">
                 <h2>What kind of coverage does the Austin Mesh network have?</h2>
                 <p>As of Summer 2024 we have coverage throughout most of downtown, central, and East Austin. We have intermittent coverage in South, Southwest (all the way to Dripping Springs), North, and even all the way up to Leander. We're actively working to expand this coverage.</p>
+                <p>We now have a coverage map showing nodes seen over the last year:</p>
+                <iframe src="https://graphs.austinmesh.org/d-solo/ddpwwgtdxf2m8f/austin-mesh?orgId=1&from=1687797112873&to=1719419512873&panelId=1" height="400" frameborder="0"></iframe>
                 <p><a href="https://meshmap.net/">The MQTT map at meshmap.net</a> is <b>not</b> representative of the coverage as we <a href="/join/#best-practices">do not recommend using MQTT</a> however it may still be useful for you to see what is in your area. Another <a href="https://canvis.app/meshtastic-map">map of <b>self reported</b> nodes</a> is also available, but more likely to be out-of-date.</p>
             </section>
             <section id="comparisons">


### PR DESCRIPTION
This is a coverage map idea for our new Grafana embedded dashboards. The modifications would look something like the below screenshot. Though, we probably want to wait merging this until we have more mapping data into InfluxDB.

<img width="1067" alt="image" src="https://github.com/austinmesh/www/assets/315485/58e30155-d6dd-4a72-95bb-ed1ededeb3f3">

