### PR TITLE
fix minor rendering issue on Safari with dropdowns

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -88,3 +88,7 @@ footer {
         display: block;
     }
 }
+menu > li:has(> menu)::after {
+    content: "▾";
+    display: inline-block;
+}


### PR DESCRIPTION
This is a minor fix for weird dropdown behavior on Safari:

![problem](https://github.com/austinmesh/www/assets/315485/9c13e0d2-9a7a-4b1f-af6c-d34c5af2c08c)

Forcing the added psuedo element to be inline fixes:

![fix](https://github.com/austinmesh/www/assets/315485/0347f73d-b52d-4862-be6b-74c53731e8ef)
