### PR TITLE
Updating Coverage Map to Only Show Nodes Seen in Last 15 Days

### DIFF
--- a/learn/index.html
+++ b/learn/index.html
@@ -151,8 +151,8 @@
             <section id="coverage">
                 <h2>What kind of coverage does the Austin Mesh network have?</h2>
                 <p>As of Summer 2024 we have coverage throughout most of downtown, central, and East Austin. We have intermittent coverage in South, Southwest (all the way to Dripping Springs), North, and even all the way up to Leander. We're actively working to expand this coverage.</p>
-                <p>We now have a coverage map showing nodes seen over the last year:</p>
-                <iframe src="https://graphs.austinmesh.org/d-solo/ddpwwgtdxf2m8f/austin-mesh?orgId=1&from=now-1y&to=now&panelId=10" height="400" frameborder="0"></iframe>
+                <p>We now have a coverage map showing nodes seen over the last 30 days:</p>
+                <iframe src="https://graphs.austinmesh.org/d-solo/ddpwwgtdxf2m8f/austin-mesh?orgId=1&from=now-30d&to=now&panelId=10" height="400" frameborder="0"></iframe>
                 <p><a href="https://meshmap.net/">The MQTT map at meshmap.net</a> is <b>not</b> representative of the coverage as we <a href="/join/#best-practices">do not recommend using MQTT</a> however it may still be useful for you to see what is in your area. Another <a href="https://canvis.app/meshtastic-map">map of <b>self reported</b> nodes</a> is also available, but more likely to be out-of-date.</p>
             </section>
             <section id="comparisons">

--- a/learn/index.html
+++ b/learn/index.html
@@ -151,8 +151,8 @@
             <section id="coverage">
                 <h2>What kind of coverage does the Austin Mesh network have?</h2>
                 <p>As of Summer 2024 we have coverage throughout most of downtown, central, and East Austin. We have intermittent coverage in South, Southwest (all the way to Dripping Springs), North, and even all the way up to Leander. We're actively working to expand this coverage.</p>
-                <p>We now have a coverage map showing nodes seen over the last 30 days:</p>
-                <iframe src="https://graphs.austinmesh.org/d-solo/ddpwwgtdxf2m8f/austin-mesh?orgId=1&from=now-30d&to=now&panelId=10" height="400" frameborder="0"></iframe>
+                <p>We now have a coverage map showing nodes seen over the last 15 days:</p>
+                <iframe src="https://graphs.austinmesh.org/d-solo/ddpwwgtdxf2m8f/austin-mesh?orgId=1&from=now-15d&to=now&panelId=10" height="400" frameborder="0"></iframe>
                 <p><a href="https://meshmap.net/">The MQTT map at meshmap.net</a> is <b>not</b> representative of the coverage as we <a href="/join/#best-practices">do not recommend using MQTT</a> however it may still be useful for you to see what is in your area. Another <a href="https://canvis.app/meshtastic-map">map of <b>self reported</b> nodes</a> is also available, but more likely to be out-of-date.</p>
             </section>
             <section id="comparisons">


### PR DESCRIPTION
I noticed that the coverage map was erroring out when trying to pull nodes seen in the last year. 

We could likely optimize the query in Grafana to resolve this, but since I lack that access I recommend cutting the time fame back to 15 days. In my testing this seems to load in a reasonable time frame and is reasonably stable.