### PR TITLE
Update DenverMesh entry to ColoradoMesh in index.html

### DIFF
--- a/similar-networks/index.html
+++ b/similar-networks/index.html
@@ -100,7 +100,7 @@
                     <li>Charlotte, North Carolina: <a href="https://charlottemesh.org/">Charlotte Mesh</a></li>
                     <li>North Carolina <a href="https://ncmesh.net/">NC Mesh</a></li>
                     <li>Chicago, Illinois: <a href="https://chicagolandmesh.org/">Chicagoland Mesh</a></li>
-                    <li>Denver, Colorado: <a href="https://denvermesh.org/">Denver Mesh</a></li>
+                    <li>Colorado: <a href="https://coloradomesh.org/">Colorado Mesh</a></li>
                     <li>Hawaii: <a href="https://www.hawaiimesh.net/">Hawaii Mesh</a></li>
                     <li>Nashville, Tennessee: <a href="https://www.instagram.com/meshville.tn">Meshville</a></li>
                     <li>Northern Texas: <a href="https://ntxmesh.com">North Texas Mesh</a></li>


### PR DESCRIPTION
DenverMesh.org has changed names to ColoradoMesh.org