### PR TITLE
muted, smaller, centered, condensed footer

### DIFF
--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -2,7 +2,7 @@
 ---
 <footer data-pagefind-ignore="all">
   <small>
-    Our website has a permissive license — feel free to use it for your club's website. See the source at <a href="https://github.com/austinmesh/www">Github</a>.
+    Our website uses a share-alike license — feel free to use it for your club's website. See the source at <a href="https://github.com/austinmesh/www">GitHub</a>.
     <br />
     If we've inspired you, please <a href="mailto:info@austinmesh.org">email us</a>! · © Tommy Ekstrand, licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA-4.0</a> · <a href="/privacy/">Privacy Policy</a>
   </small>

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -1,10 +1,9 @@
 ---
 ---
 <footer data-pagefind-ignore="all">
-  <p>Our website content is licensed under Creative Commons
-    <br>feel free to use it for your club's website: <a href="https://github.com/austinmesh/www">Github</a>
-    <br>If we've inspired you, please <a href="mailto:info@austinmesh.org">email us</a>!
-    <br>This site is (c) by Tommy Ekstrand and is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License.
-    <br><a href="/privacy/">Privacy Policy</a>
-  </p>
+  <small>
+    Our website has a permissive license — feel free to use it for your club's website. See the source at <a href="https://github.com/austinmesh/www">Github</a>.
+    <br />
+    If we've inspired you, please <a href="mailto:info@austinmesh.org">email us</a>! · © Tommy Ekstrand, licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA-4.0</a> · <a href="/privacy/">Privacy Policy</a>
+  </small>
 </footer>

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -68,6 +68,8 @@ main {
 footer {
     margin: 0 auto !important;
     max-width: 900px;
+    text-align: center;
+    color: light-dark(#777, #999);
 }
 .hero {
     position: relative;


### PR DESCRIPTION
I was never a fan of the site footer. This is a more muted, centered, and condensed design with some slight wording changes. Let me know what you think.

New:
<img width="934" height="309" alt="image" src="https://github.com/user-attachments/assets/1c0ef4b2-2f60-4472-9bbe-c11e608f5b1d" />

Old:
<img width="970" height="392" alt="image" src="https://github.com/user-attachments/assets/b76eec91-87de-4fff-86e3-c22f71a927e0" />
